### PR TITLE
:priority option broken

### DIFF
--- a/lib/carmen/rails/action_view/form_helper.rb
+++ b/lib/carmen/rails/action_view/form_helper.rb
@@ -131,7 +131,8 @@ module ActionView
       #
       # Returns an `html_safe` string containing the HTML for a select element.
       def subregion_select_tag(name, value, parent_region_or_code, options = {}, html_options = {})
-        options.stringify_keys!
+        # DD: this breaks the options: 
+        # options.stringify_keys!
         parent_region = determine_parent(parent_region_or_code)
         priority_regions = options.delete(:priority) || []
         opts = region_options_for_select(parent_region.subregions, value, :priority => priority_regions)


### PR DESCRIPTION
Small bug fix.  I found that the "options.stringify_keys!" would break search for the :priority symbol in the options hash.
