### PR TITLE
Country Subregion sort

### DIFF
--- a/lib/carmen/rails/action_view/form_helper.rb
+++ b/lib/carmen/rails/action_view/form_helper.rb
@@ -85,7 +85,7 @@ module ActionView
         end
 
         main_options = regions.map { |r| [r.name, r.code] }
-        main_options.sort!{|a, b| a.first.unpack('U').to_s <=> b.first.unpack('U').to_s}
+        main_options.sort!{|a, b| a.first.to_s <=> b.first.to_s}
         region_options += options_for_select(main_options, selected)
         region_options.html_safe
       end


### PR DESCRIPTION
Removing the unpack('U') was sorting the countries and states in the correct order.
