### PR TITLE
allows to set multiple groups of priority regions

### DIFF
--- a/lib/carmen/rails/action_view/form_helper.rb
+++ b/lib/carmen/rails/action_view/form_helper.rb
@@ -88,14 +88,16 @@ module ActionView
           unless regions.respond_to?(:coded)
             regions = Carmen::RegionCollection.new(regions)
           end
-
-          priority_regions = priority_region_codes.map do |code|
-            region = regions.coded(code)
-            [region.name, region.code] if region
-          end.compact
-          unless priority_regions.empty?
-            region_options += options_for_select(priority_regions, selected)
-            region_options += "<option disabled>-------------</option>"
+          priority_region_codes = [priority_region_codes] unless priority_region_codes.first.is_a?(Array)
+          priority_region_codes.each do |prc|
+            priority_regions = prc.map do |code|
+              region = regions.coded(code)
+              [region.name, region.code] if region
+            end.compact
+            unless priority_regions.empty?
+              region_options += options_for_select(priority_regions, selected)
+              region_options += "<option disabled>-------------</option>"
+            end
           end
         end
 

--- a/spec/carmen/action_view/helpers/form_helper_spec.rb
+++ b/spec/carmen/action_view/helpers/form_helper_spec.rb
@@ -207,6 +207,21 @@ class CarmenViewHelperTest < MiniTest::Unit::TestCase
     assert_equal_markup(expected, html)
   end
 
+  def test_region_options_for_select_with_multiple_groups_of_priority
+    html = region_options_for_select(Carmen::Country.all, nil, priority: [['ES'], ['EU']])
+      expected = <<-HTML
+        <option value="ES">Eastasia</option>
+        <option disabled>-------------</option>
+        <option value="EU">Eurasia</option>
+        <option disabled>-------------</option>
+        <option value="ES">Eastasia</option>
+        <option value="EU">Eurasia</option>
+        <option value="OC">Oceania</option>
+      HTML
+
+      assert_equal_markup(expected, html)
+  end
+
   def test_form_builder_country_select
     form = ActionView::Helpers::FormBuilder.new(:object, @object, self, {}, lambda{})
 


### PR DESCRIPTION
This changes allows to set several groups of priority regions by passing two dimensional array without breaking current API. So, for example by passing :priority attribute as a two dimensional array like [ [ 'AU' , 'NZ' ], [ 'US' , 'CA'] ] will generate a two groups of priority countries separated by ---------- . Current API with one dimensional array will work as well.   
