### PR TITLE
Modified country_select to permit passing :object as an option.

### DIFF
--- a/lib/carmen/rails/action_view/form_helper.rb
+++ b/lib/carmen/rails/action_view/form_helper.rb
@@ -62,7 +62,7 @@ module ActionView
 
         html_options ||= {}
 
-        tag = InstanceTag.new(object, method, self)
+        tag = InstanceTag.new(object, method, self, options.delete(:object))
         tag.to_region_select_tag(Carmen::World.instance, options, html_options)
       end
 


### PR DESCRIPTION
I'm faced with the following scenario:
- Using Formtastic to generate forms
- Using a nested form:
  - form is created for an Order model object
  - sub-form is created for an Address model object
  - using `form.input :as => :country` as the form-field for the Address country

The Address object was not being passed through the whole field generation stack so therefore the previously-set value for the Address country was not being pre-selected in the country_select.

To fix this, I've added the ability for `country_select` to pull the `object` from the `args` in the same way that `subregion_select` does.  That way I can pass the object manually from my sub-form, e.g.:

```
= subform.input :country_code, :as => :country, 
                :priority_countries => %w[US CA], 
                :object => subform.object
```
