### PR TITLE
rails4 compatibility

### DIFF
--- a/lib/carmen/rails/action_view/form_helper.rb
+++ b/lib/carmen/rails/action_view/form_helper.rb
@@ -83,6 +83,7 @@ module ActionView
         options.stringify_keys!
         priority_region_codes = options['priority'] || []
         region_options = ""
+        region_options += options_for_select [[options['prompt'], '']] if options['prompt']
 
         unless priority_region_codes.empty?
           unless regions.respond_to?(:coded)
@@ -101,7 +102,6 @@ module ActionView
 
         main_options = regions.map { |r| [r.name, r.code] }
         main_options.sort!{|a, b| a.first.to_s <=> b.first.to_s}
-        main_options.unshift [options['prompt'], ''] if options['prompt']
 
         region_options += options_for_select(main_options, selected)
         region_options.html_safe

--- a/lib/carmen/rails/action_view/form_helper.rb
+++ b/lib/carmen/rails/action_view/form_helper.rb
@@ -124,8 +124,8 @@ module ActionView
       #   country_select_tag('country_code', {priority: ['US', 'CA']}, class: 'region')
       #
       # Returns an `html_safe` string containing the HTML for a select element.
-      def country_select_tag(name, value, options={})
-        subregion_select_tag(name, value, Carmen::World.instance, options)
+      def country_select_tag(name, value, options={}, html_options={})
+        subregion_select_tag(name, value, Carmen::World.instance, options, html_options)
       end
 
       # Generate select and subregion option tags for the given object and method. A

--- a/lib/carmen/rails/action_view/form_helper.rb
+++ b/lib/carmen/rails/action_view/form_helper.rb
@@ -171,8 +171,13 @@ module ActionView
         end
       end
     end
-
-    class InstanceTag < ActionView::Helpers::Tags::Base
+    
+    if Rails.version > '4'
+      class InstanceTag < ActionView::Helpers::Tags::Base
+      end
+    end
+    
+    class InstanceTag
       def to_region_select_tag(parent_region, options = {}, html_options = {})
         html_options = html_options.stringify_keys
         add_default_name_and_id(html_options)

--- a/lib/carmen/rails/action_view/form_helper.rb
+++ b/lib/carmen/rails/action_view/form_helper.rb
@@ -171,12 +171,12 @@ module ActionView
         end
       end
     end
-    
-    if Rails.version > '4'
+
+    if Rails.version.to_s > '4'
       class InstanceTag < ActionView::Helpers::Tags::Base
       end
     end
-    
+
     class InstanceTag
       def to_region_select_tag(parent_region, options = {}, html_options = {})
         html_options = html_options.stringify_keys

--- a/lib/carmen/rails/action_view/form_helper.rb
+++ b/lib/carmen/rails/action_view/form_helper.rb
@@ -172,7 +172,7 @@ module ActionView
       end
     end
 
-    class InstanceTag
+    class InstanceTag < ActionView::Helpers::Tags::Base
       def to_region_select_tag(parent_region, options = {}, html_options = {})
         html_options = html_options.stringify_keys
         add_default_name_and_id(html_options)


### PR DESCRIPTION
Hey, this isn't backwards compatible with rails3, but was necessary to get the form_helper to work with rails4.
