### PR TITLE
correctly honors use of selected option in subregion_select method

### DIFF
--- a/lib/carmen/rails/action_view/form_helper.rb
+++ b/lib/carmen/rails/action_view/form_helper.rb
@@ -177,7 +177,7 @@ module ActionView
         html_options = html_options.stringify_keys
         add_default_name_and_id(html_options)
         priority_regions = options[:priority] || []
-        value = value(object)
+        value = value(object) ? value(object) : options[:selected]
         opts = add_options(region_options_for_select(parent_region.subregions, value, :priority => priority_regions), options, value)
         content_tag("select", opts, html_options)
       end

--- a/spec/carmen/action_view/helpers/form_helper_spec.rb
+++ b/spec/carmen/action_view/helpers/form_helper_spec.rb
@@ -136,10 +136,25 @@ class CarmenViewHelperTest < MiniTest::Unit::TestCase
     oceania = Carmen::Country.coded('OC')
 
     @html = subregion_select(@object, :subregion_code, oceania)
-
     assert_select('option[selected="selected"][value="AO"]')
   end
 
+  def test_subregion_selected_value_with_priority_and_selected_options
+    @object.subregion_code = 'AO'
+    oceania = Carmen::Country.coded('OC')
+    @html = subregion_select(@object, :subregion_code, oceania, { priority: ['AO'], selected: 'AO' })
+
+    assert_select('option[selected="selected"][value="AO"]')  
+  end
+
+  def test_html_options_for_selected_value_with_priority_and_selected_options
+    @object.subregion_code = 'AO'
+    oceania = Carmen::Country.coded('OC')
+    @html = subregion_select(@object, :subregion_code, oceania, { priority: ['AO'], selected: 'AO' }, { class: :test_html_options})
+
+    assert_select('.test_html_options')
+  end
+  
   def test_basic_subregion_select_tag
     oceania = Carmen::Country.coded('OC')
     expected = <<-HTML
@@ -238,4 +253,5 @@ class CarmenViewHelperTest < MiniTest::Unit::TestCase
 
     assert_equal_markup(expected, html)
   end
+  
 end


### PR DESCRIPTION
The 'selected' option was not being honored when using the subregion select method.

``` erb
<%= subregion_select f.object_name, :state, 'US', { selected: f.object.state ,  :prompt => 'State or Territory' } %>
```
