### PR TITLE
Ensure form object is passed down to InstanceTag

### DIFF
--- a/lib/carmen/rails/action_view/form_helper.rb
+++ b/lib/carmen/rails/action_view/form_helper.rb
@@ -51,16 +51,14 @@ module ActionView
       #   country_select(@object, :region, ['US', 'CA'], class: region)
       #
       # Returns an `html_safe` string containing the HTML for a select element.
-      def country_select(object, method, *args)
-
-        # These contortions are to provide API-compatibility
-        priority_countries = args.shift if args.first.is_a?(Array)
-        options, html_options = args
-
-        options ||= {}
-        options[:priority] = priority_countries if priority_countries
-
-        html_options ||= {}
+      def country_select(object, method, priorities_or_options = {}, options_or_html_options = {}, html_options = {})
+        if priorities_or_options.is_a? Array
+          options = options_or_html_options
+          options[:priority] = priorities_or_options
+        else
+          options = priorities_or_options
+          html_options = options_or_html_options
+        end
 
         tag = InstanceTag.new(object, method, self, options.delete(:object))
         tag.to_region_select_tag(Carmen::World.instance, options, html_options)
@@ -189,8 +187,16 @@ module ActionView
       # web form.
       #
       # See `FormOptionsHelper::country_select` for more information.
-      def country_select(method, *args)
-        @template.country_select(@object_name, method, *args)
+      def country_select(method, priorities_or_options = {}, options_or_html_options = {}, html_options = {})
+        if priorities_or_options.is_a? Array
+          options = options_or_html_options
+          options[:priority] = priorities_or_options
+        else
+          options = priorities_or_options
+          html_options = options_or_html_options
+        end
+
+        @template.country_select(@object_name, method, objectify_options(options), @default_options.merge(html_options))
       end
 
       # Generate select and subregion option tags with the provided name. A
@@ -198,8 +204,8 @@ module ActionView
       # a given country.
       #
       # See `FormOptionsHelper::subregion_select` for more information.
-      def subregion_select(method, parent_region_or_code, *args)
-        @template.subregion_select(@object_name, method, parent_region_or_code, *args)
+      def subregion_select(method, parent_region_or_code, options = {}, html_options = {})
+        @template.subregion_select(@object_name, method, parent_region_or_code, objectify_options(options), @default_options.merge(html_options))
       end
     end
 

--- a/spec/carmen/action_view/helpers/form_helper_spec.rb
+++ b/spec/carmen/action_view/helpers/form_helper_spec.rb
@@ -15,7 +15,7 @@ class CarmenViewHelperTest < MiniTest::Unit::TestCase
   end
 
   def test_basic_country_select
-    html = country_select(@object, :country_code)
+    html = country_select(:object, :country_code)
     expected = <<-HTML
       <select id="object_country_code" name="object[country_code]">
         <option value="ES">Eastasia</option>
@@ -28,8 +28,7 @@ class CarmenViewHelperTest < MiniTest::Unit::TestCase
   end
 
   def test_country_selected_value
-    @object.country_code = 'OC'
-    @html = country_select(@object, :country_code)
+    @html = country_select(:object, :country_code, :selected => 'OC')
     assert_select('option[selected="selected"][value="OC"]')
   end
 
@@ -65,7 +64,7 @@ class CarmenViewHelperTest < MiniTest::Unit::TestCase
   end
 
   def test_priority_country_select
-    html = country_select(@object, :country_code, :priority => ['ES'])
+    html = country_select(:object, :country_code, :priority => ['ES'])
     expected = <<-HTML
       <select id="object_country_code" name="object[country_code]">
         <option value="ES">Eastasia</option>
@@ -80,7 +79,7 @@ class CarmenViewHelperTest < MiniTest::Unit::TestCase
   end
 
   def test_priority_country_select_deprecated_api
-    html = country_select(@object, :country_code, ['ES'], {})
+    html = country_select(:object, :country_code, ['ES'], {})
     expected = <<-HTML
       <select id="object_country_code" name="object[country_code]">
         <option value="ES">Eastasia</option>
@@ -102,7 +101,7 @@ class CarmenViewHelperTest < MiniTest::Unit::TestCase
       </select>
     HTML
 
-    html = subregion_select(@object, :subregion_code, oceania)
+    html = subregion_select(:object, :subregion_code, oceania)
 
     assert_equal_markup(expected, html)
   end
@@ -114,7 +113,7 @@ class CarmenViewHelperTest < MiniTest::Unit::TestCase
       </select>
     HTML
 
-    html = subregion_select(@object, :subregion_code, 'OC')
+    html = subregion_select(:object, :subregion_code, 'OC')
 
     assert_equal_markup(expected, html)
   end
@@ -126,35 +125,32 @@ class CarmenViewHelperTest < MiniTest::Unit::TestCase
       </select>
     HTML
 
-    html = subregion_select(@object, :subregion_code, ['OC', 'AO'])
+    html = subregion_select(:object, :subregion_code, ['OC', 'AO'])
 
     assert_equal_markup(expected, html)
   end
 
   def test_subregion_selected_value
-    @object.subregion_code = 'AO'
     oceania = Carmen::Country.coded('OC')
 
-    @html = subregion_select(@object, :subregion_code, oceania)
+    @html = subregion_select(:object, :subregion_code, oceania, :selected => 'AO')
     assert_select('option[selected="selected"][value="AO"]')
   end
 
   def test_subregion_selected_value_with_priority_and_selected_options
-    @object.subregion_code = 'AO'
     oceania = Carmen::Country.coded('OC')
-    @html = subregion_select(@object, :subregion_code, oceania, { priority: ['AO'], selected: 'AO' })
+    @html = subregion_select(:object, :subregion_code, oceania, { priority: ['AO'], selected: 'AO' })
 
-    assert_select('option[selected="selected"][value="AO"]')  
+    assert_select('option[selected="selected"][value="AO"]')
   end
 
   def test_html_options_for_selected_value_with_priority_and_selected_options
-    @object.subregion_code = 'AO'
     oceania = Carmen::Country.coded('OC')
-    @html = subregion_select(@object, :subregion_code, oceania, { priority: ['AO'], selected: 'AO' }, { class: :test_html_options})
+    @html = subregion_select(:object, :subregion_code, oceania, { priority: ['AO'], selected: 'AO' }, { class: :test_html_options})
 
     assert_select('.test_html_options')
   end
-  
+
   def test_basic_subregion_select_tag
     oceania = Carmen::Country.coded('OC')
     expected = <<-HTML
@@ -237,6 +233,14 @@ class CarmenViewHelperTest < MiniTest::Unit::TestCase
     assert_equal_markup(expected, html)
   end
 
+  def test_form_builder_selected_country
+    @object.country_code = 'OC'
+    form = ActionView::Helpers::FormBuilder.new(:object, @object, self, {}, lambda{})
+    @html = form.country_select('country_code')
+
+    assert_select('option[selected="selected"][value="OC"]')
+  end
+
   def test_form_builder_country_select_deprecated_api
     form = ActionView::Helpers::FormBuilder.new(:object, @object, self, {}, lambda{})
 
@@ -253,5 +257,24 @@ class CarmenViewHelperTest < MiniTest::Unit::TestCase
 
     assert_equal_markup(expected, html)
   end
-  
+
+  def test_form_builder_subregion_select
+    form = ActionView::Helpers::FormBuilder.new(:object, @object, self, {}, lambda{})
+    html = form.subregion_select(:subregion_code, 'OC')
+    expected = <<-HTML
+      <select id="object_subregion_code" name="object[subregion_code]">
+        <option value="AO">Airstrip One</option>
+      </select>
+    HTML
+
+    assert_equal_markup(expected, html)
+  end
+
+  def test_form_builder_selected_subregion
+    @object.subregion_code = 'AO'
+    form = ActionView::Helpers::FormBuilder.new(:object, @object, self, {}, lambda{})
+    @html = form.subregion_select(:subregion_code, 'OC')
+
+    assert_select('option[selected="selected"][value="AO"]')
+  end
 end


### PR DESCRIPTION
The `country_select` and `subregion_select` methods on
`ActionView::Helpers::FormBuilder` do not update the `options` hash with
the `:object` key, resulting in the value of the object passed into the
form builder not being selected in the HTML output.

Updated `FormBuilder` methods to add its object to the `options` hash and
cleaned up the logic for supporting the legacy API for priority
countries.

Add tests for these regressions and update the test suite to pass a
symbol instead of an `OpenStruct` instance when using the
`FormOptionsHelper` methods as this is the intended API for these
methods (based on what I can glean from the Rails APIs and code).
