### PR TITLE
When a priority region is selected, don't select it twice in the markup

### DIFF
--- a/lib/carmen/rails/action_view/form_helper.rb
+++ b/lib/carmen/rails/action_view/form_helper.rb
@@ -96,6 +96,11 @@ module ActionView
           unless priority_regions.empty?
             region_options += options_for_select(priority_regions, selected)
             region_options += "<option disabled>-------------</option>"
+
+            # If a priority region is selected, don't select it again in the main list.
+            # This prevents some browsers from selecting the second occurance of this region,
+            # which makes it difficult to select an alternative priority region.
+            selected = nil if priority_region_codes.include?(selected)
           end
         end
 

--- a/spec/carmen/action_view/helpers/form_helper_spec.rb
+++ b/spec/carmen/action_view/helpers/form_helper_spec.rb
@@ -94,6 +94,23 @@ class CarmenViewHelperTest < MiniTest::Unit::TestCase
     assert_equal_markup(expected, html)
   end
 
+  def test_country_select_selected_priority_region_not_selected_twice
+    @object.country_code = 'ES'
+
+    html = country_select(@object, :country_code, :priority => ['ES'])
+    expected = <<-HTML
+      <select id="object_country_code" name="object[country_code]">
+        <option value="ES" selected="selected">Eastasia</option>
+        <option disabled>-------------</option>
+        <option value="ES">Eastasia</option>
+        <option value="EU">Eurasia</option>
+        <option value="OC">Oceania</option>
+      </select>
+    HTML
+
+    assert_equal_markup(expected, html)
+  end
+
   def test_basic_subregion_select
     oceania = Carmen::Country.coded('OC')
     expected = <<-HTML
@@ -144,7 +161,7 @@ class CarmenViewHelperTest < MiniTest::Unit::TestCase
     oceania = Carmen::Country.coded('OC')
     @html = subregion_select(@object, :subregion_code, oceania, { priority: ['AO'], selected: 'AO' })
 
-    assert_select('option[selected="selected"][value="AO"]')  
+    assert_select('option[selected="selected"][value="AO"]')
   end
 
   def test_html_options_for_selected_value_with_priority_and_selected_options
@@ -154,7 +171,7 @@ class CarmenViewHelperTest < MiniTest::Unit::TestCase
 
     assert_select('.test_html_options')
   end
-  
+
   def test_basic_subregion_select_tag
     oceania = Carmen::Country.coded('OC')
     expected = <<-HTML
@@ -253,5 +270,5 @@ class CarmenViewHelperTest < MiniTest::Unit::TestCase
 
     assert_equal_markup(expected, html)
   end
-  
+
 end


### PR DESCRIPTION
If a priority region is selected on the `country_select`, it is selected again in the main list. This causes some browsers (notably, the latest version of Chrome) to select the second occurrence of this region, which makes it difficult to select an alternative priority region.

Added a spec to cover this, and ensured the spec suite passes.

See also [this pull request](https://github.com/jamesds/country-select/pull/3).

P.S. Thanks a lot for this gem, and for Carmen. The codebase and test suite were a real pleasure to navigate, and modify. Great to see that every once in a while!
