### PR TITLE
Rails 4 integration and Travis matrix integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .bundle/
 log/*.log
 pkg/
+Gemfile.lock
 .DS_Store

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,15 @@
 rvm:
   - 1.9.2
   - 1.9.3
-
+  - 2.0.0
+env:
+  - "RAILS_VERSION=3.1.0"
+  - "RAILS_VERSION=3.2.0"
+  - "RAILS_VERSION=4.0.0"
+matrix:
+  exclude:
+    - rvm: 1.9.2
+      env: "RAILS_VERSION=4.0.0"
 branches:
   only:
     - master

--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,16 @@ source "http://rubygems.org"
 # development dependencies will be added by default to the :development group.
 
 gemspec
+
+rails_version = ENV["RAILS_VERSION"] || "default"
+
+rails = case rails_version
+when "master"
+  {github: "rails/rails"}
+when "default"
+  ">= 3.1.0"
+else
+  "~> #{rails_version}"
+end
+
+gem "rails", rails

--- a/Rakefile
+++ b/Rakefile
@@ -1,19 +1,15 @@
-#!/usr/bin/env rake
-begin
-  require 'bundler/setup'
-rescue LoadError
-  puts 'You must `gem install bundler` and `bundle install` to run rake tasks'
-end
+require 'rake'
+require 'rake/testtask'
+require 'rdoc/task'
 
 Bundler::GemHelper.install_tasks
 
-require 'rake/testtask'
-
-Rake::TestTask.new(:spec) do |t|
+Rake::TestTask.new(:test) do |t|
   t.libs << 'lib'
-  t.libs << 'spec'
-  t.pattern = 'spec/**/*_spec.rb'
-  t.verbose = false
+  t.libs << 'test'
+  t.pattern = 'test/**/*_test.rb'
+  t.verbose = true
 end
 
-task :default => :spec
+desc 'Default: run unit tests.'
+task :default => :test

--- a/test/carmen/action_view/helpers/form_helper_test.rb
+++ b/test/carmen/action_view/helpers/form_helper_test.rb
@@ -199,11 +199,19 @@ class CarmenViewHelperTest < MiniTest::Unit::TestCase
 
   def test_region_options_for_select
     regions = Carmen::Country.all
-    expected = <<-HTML
-      <option value="ES">Eastasia</option>
-      <option value="EU">Eurasia</option>
-      <option value="OC" selected="selected">Oceania</option>
-    HTML
+    if Rails::VERSION::MAJOR == 3
+      expected = <<-HTML
+        <option value="ES">Eastasia</option>
+        <option value="EU">Eurasia</option>
+        <option value="OC" selected="selected">Oceania</option>
+      HTML
+    else
+      expected = <<-HTML
+        <option value="ES">Eastasia</option>
+        <option value="EU">Eurasia</option>
+        <option selected="selected" value="OC">Oceania</option>
+      HTML
+    end
     html = region_options_for_select(regions, 'OC')
 
     assert_equal_markup(expected, html)

--- a/test/carmen/action_view/helpers/form_helper_test.rb
+++ b/test/carmen/action_view/helpers/form_helper_test.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'test_helper'
 
 class CarmenViewHelperTest < MiniTest::Unit::TestCase
   include ActionView::Helpers::FormOptionsHelper

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,8 +1,8 @@
 lib_path = File.expand_path('../../lib', __FILE__)
 $LOAD_PATH.unshift(lib_path)
 
-require 'minitest/spec'
 require 'minitest/autorun'
+require 'minitest/spec'
 
 require 'action_view/test_case'
 


### PR DESCRIPTION
In this PR:

1) Made the Gemfile configurable in terms of Rails version
2) Updated the Travis CI matrix to include Ruby 2.0 and Rails versions 3.1.x, 3.2.x, and 4.0.x
3) Moved the tests to the standard file location for Minitest tests
4) Updated the helper code to work with Rails 4 when generating select/option tags
5) Updated the test to accommodate changes in tag output between Rails 3 and Rails 4

Travis CI passes for all elements of the matrix
