### PR TITLE
Add in missing html_options param for "subregion_select_tag"

### DIFF
--- a/lib/carmen/rails/action_view/form_helper.rb
+++ b/lib/carmen/rails/action_view/form_helper.rb
@@ -124,8 +124,8 @@ module ActionView
       #   country_select_tag('country_code', {priority: ['US', 'CA']}, class: 'region')
       #
       # Returns an `html_safe` string containing the HTML for a select element.
-      def country_select_tag(name, value, options={})
-        subregion_select_tag(name, value, Carmen::World.instance, options)
+      def country_select_tag(name, value, options={}, html_options={})
+        subregion_select_tag(name, value, Carmen::World.instance, options, html_options)
       end
 
       # Generate select and subregion option tags for the given object and method. A

--- a/lib/carmen/rails/action_view/form_helper.rb
+++ b/lib/carmen/rails/action_view/form_helper.rb
@@ -112,6 +112,7 @@ module ActionView
       # inside a web form.
       #
       # name         - The name attribute for the select element.
+      # value        - An instance of Carmen::Region or 2-Character country code.
       # options      - Other options pertaining to option tag generation. See
       #                `region_options_for_select`.
       # html_options - Options to use when generating the select tag- class,
@@ -121,7 +122,7 @@ module ActionView
       #
       # Example:
       #
-      #   country_select_tag('country_code', {priority: ['US', 'CA']}, class: 'region')
+      #   country_select_tag('country_code', 'US', {priority: ['US', 'CA']}, class: 'region')
       #
       # Returns an `html_safe` string containing the HTML for a select element.
       def country_select_tag(name, value, options={}, html_options={})


### PR DESCRIPTION
country_select_tag passes html_options to subregion_select_tag which did not accept html_options thus loosing any modifications to the HTML for the country_select_tag.
