### PR TITLE
Passing {object: Thing} into ActionView::Helpers::Tags::Base for simple_form

### DIFF
--- a/lib/carmen/rails/action_view/form_helper.rb
+++ b/lib/carmen/rails/action_view/form_helper.rb
@@ -24,7 +24,7 @@ module ActionView
       # Returns an `html_safe` string containing the HTML for a select element.
       def subregion_select(object, method, parent_region_or_code, options={}, html_options={})
         parent_region = determine_parent(parent_region_or_code)
-        tag = instance_tag(object, method, self, options.delete(:object))
+        tag = instance_tag(object, method, self, options)
         tag.to_region_select_tag(parent_region, options, html_options)
       end
 
@@ -62,7 +62,7 @@ module ActionView
 
         html_options ||= {}
 
-        tag = instance_tag(object, method, self, options.delete(:object))
+        tag = instance_tag(object, method, self, options)
         tag.to_region_select_tag(Carmen::World.instance, options, html_options)
       end
 
@@ -160,7 +160,7 @@ module ActionView
 
       def instance_tag(object_name, method_name, template_object, options = {})
         if Rails::VERSION::MAJOR == 3
-          InstanceTag.new(object_name, method_name, template_object, options)
+          InstanceTag.new(object_name, method_name, template_object, options.delete(:object))
         else
           ActionView::Helpers::Tags::Base.new(object_name, method_name, template_object, options || {})
         end

--- a/test/carmen/action_view/helpers/form_helper_test.rb
+++ b/test/carmen/action_view/helpers/form_helper_test.rb
@@ -33,6 +33,14 @@ class CarmenViewHelperTest < MiniTest::Unit::TestCase
     assert_select('option[selected="selected"][value="OC"]')
   end
 
+  def test_country_selected_object_option
+    @object.country_code = 'OC'
+    override_object = OpenStruct.new(:country_code => 'ES')
+    @html = country_select(@object, :country_code, {:object => override_object})
+
+    assert_select('option[selected="selected"][value="ES"]')
+  end
+
   def test_basic_country_select_tag
     html = country_select_tag('attribute_name', nil)
     expected = <<-HTML


### PR DESCRIPTION
Fixes an issue with using simple_form and rails4 disallowing you to pass in {object: f.object} properly.
