### PR TITLE
add missing html_options parameter to country_select_tag

### DIFF
--- a/lib/carmen/rails/action_view/form_helper.rb
+++ b/lib/carmen/rails/action_view/form_helper.rb
@@ -127,8 +127,8 @@ module ActionView
       #   country_select_tag('country_code', {priority: ['US', 'CA']}, class: 'region')
       #
       # Returns an `html_safe` string containing the HTML for a select element.
-      def country_select_tag(name, value, options={})
-        subregion_select_tag(name, value, Carmen::World.instance, options)
+      def country_select_tag(name, value, options={}, html_options={})
+        subregion_select_tag(name, value, Carmen::World.instance, options, html_options)
       end
 
       # Generate select and subregion option tags for the given object and method. A


### PR DESCRIPTION
I can't set html_options like {class: 'my-class', id: 'my id'} without passing through the parameter.
