### PR TITLE
disable i18n fallback

### DIFF
--- a/lib/carmen-rails.rb
+++ b/lib/carmen-rails.rb
@@ -11,9 +11,6 @@ module Carmen
       }.flatten.compact
       Carmen.i18n_backend = ::I18n
       config.i18n.load_path += paths
-
-      # Enable fallbacks so that missing translations use the default locale
-      config.i18n.fallbacks = true
     end
   end
 end


### PR DESCRIPTION
We need to remove this fallback to get the default behavior from rails environment specific configurations (production enabled but development, test etc. disabled).
