### PR TITLE
Update form_helper.rb for Rails 5.2

### DIFF
--- a/lib/carmen/rails/action_view/form_helper.rb
+++ b/lib/carmen/rails/action_view/form_helper.rb
@@ -197,15 +197,20 @@ module ActionView
       end
     end
 
-    if Rails::VERSION::MAJOR == 4
+    if [4, 5].include? Rails::VERSION::MAJOR
       module Tags
         class Base
           def to_region_select_tag(parent_region, options = {}, html_options = {})
             html_options = html_options.stringify_keys
             add_default_name_and_id(html_options)
-            options[:include_blank] ||= true unless options[:prompt] || select_not_required?(html_options)
 
-            value = options[:selected] ? options[:selected] : value(object)
+            if (Rails::VERSION::MAJOR == 4 && !select_not_required?(html_options)) ||
+               (Rails::VERSION::MAJOR == 5 && placeholder_required?(html_options))
+              raise ArgumentError, "include_blank cannot be false for a required field." if options[:include_blank] == false
+              options[:include_blank] ||= true unless options[:prompt]
+            end
+
+            value = options[:selected] ? options[:selected] : value
             priority_regions = options[:priority] || []
             opts = add_options(region_options_for_select(parent_region.subregions, value, 
                                                         :priority => priority_regions), 


### PR DESCRIPTION
Fix wrong number of arguments error on `value(object)`